### PR TITLE
COMP: Use nullptr instead of 0 or NULL

### DIFF
--- a/BrukerT1Map.cxx
+++ b/BrukerT1Map.cxx
@@ -126,8 +126,7 @@ int main(int argc, char **argv)
   dims[2] = imageIO->GetDimensions(2);
 
   // Extract repetition/inversion times depending on the algorithm.
-  Bruker2DSEQImageIOType::ACQRepetitionTimeContainerType::Pointer ptrToTimePoints
-    = NULL;
+  Bruker2DSEQImageIOType::ACQRepetitionTimeContainerType::Pointer ptrToTimePoints = nullptr;
   if((algorithm == MRT1ParameterMap3DImageFilterType::IDEAL_STEADY_STATE) ||
     (algorithm == MRT1ParameterMap3DImageFilterType::HYBRID_STEADY_STATE_3PARAM))
     {
@@ -285,8 +284,8 @@ int main(int argc, char **argv)
       }
     }
   // Not needed anymore.
-  t1Mask = NULL;
-  baselineReader = NULL;
+  t1Mask = nullptr;
+  baselineReader = nullptr;
 
   // Create T1 mapping class.
   MRT1ParameterMap3DImageFilterType::Pointer t1Map =

--- a/BrukerT2Map.cxx
+++ b/BrukerT2Map.cxx
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
   dims[2] = imageIO->GetDimensions(2);
 
   // Get the echo times in ms.
-  Bruker2DSEQImageIOType::ACQEchoTimeContainerType::Pointer ptrToEchoes = NULL;
+  Bruker2DSEQImageIOType::ACQEchoTimeContainerType::Pointer ptrToEchoes = nullptr;
   if(!itk::ExposeMetaData<
     Bruker2DSEQImageIOType::ACQEchoTimeContainerType::Pointer>
    (imageIO->GetMetaDataDictionary(),itk::ACQ_ECHO_TIME,ptrToEchoes))
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
         }
       }
     }
-  baselineReader = NULL; // Not needed anymore.
+  baselineReader = nullptr; // Not needed anymore.
 
   // Create T2 mapping class.
   MRT2ParameterMap3DImageFilterType::Pointer t2Map

--- a/PhilipsT1Map.cxx
+++ b/PhilipsT1Map.cxx
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
 
   // Get rescale values.
   PhilipsRECImageIOType::ScanningSequenceImageTypeRescaleValuesContainerType
-    ::Pointer scanSequenceImageTypeRescaleValues = NULL;
+    ::Pointer scanSequenceImageTypeRescaleValues = nullptr;
   if( !itk::ExposeMetaData<PhilipsRECImageIOType::
     ScanningSequenceImageTypeRescaleValuesContainerType::Pointer>
     (imageIO->GetMetaDataDictionary(),
@@ -263,8 +263,7 @@ int main(int argc, char **argv)
     }
 
   // Get trigger times.
-  PhilipsRECImageIOType::TriggerTimesContainerType::Pointer ptrToTimePoints =
-    NULL;
+  PhilipsRECImageIOType::TriggerTimesContainerType::Pointer ptrToTimePoints = nullptr;
   if(!itk::ExposeMetaData<
     PhilipsRECImageIOType::TriggerTimesContainerType::Pointer>
     (imageIO->GetMetaDataDictionary(),itk::PAR_TriggerTimes,ptrToTimePoints) )
@@ -301,8 +300,8 @@ int main(int argc, char **argv)
     }
 
   // Change image to floating point value.
-  ShiftScaleImageFilterType::Pointer scaleOnly = NULL;
-  ShiftScaleInPlaceImageFilterType::Pointer shiftAndScale = NULL;
+  ShiftScaleImageFilterType::Pointer scaleOnly = nullptr;
+  ShiftScaleInPlaceImageFilterType::Pointer shiftAndScale = nullptr;
   PhilipsRECImageIOType::ImageTypeRescaleValuesType rescaleValues;
   if((algorithm == MRT1ParameterMap3DImageFilterType::INVERSION_RECOVERY) ||
     (algorithm == MRT1ParameterMap3DImageFilterType::INVERSION_RECOVERY_3PARAM)

--- a/PhilipsT2Map.cxx
+++ b/PhilipsT2Map.cxx
@@ -204,7 +204,7 @@ int main(int argc, char **argv)
 
   // Get rescale values for converting the 16 bit image to floating point.
   PhilipsRECImageIOType::ScanningSequenceImageTypeRescaleValuesContainerType
-    ::Pointer scanSequenceImageTypeRescaleValues = NULL;
+    ::Pointer scanSequenceImageTypeRescaleValues = nullptr;
   if( !itk::ExposeMetaData<PhilipsRECImageIOType
     ::ScanningSequenceImageTypeRescaleValuesContainerType::Pointer>
     (imageIO->GetMetaDataDictionary(),
@@ -253,8 +253,8 @@ int main(int argc, char **argv)
   t2Mask->ThresholdBelow(threshold);
 
   // Change image to floating point value.
-  ShiftScaleImageFilterType::Pointer scaleOnly = NULL;
-  ShiftScaleInPlaceImageFilterType::Pointer shiftAndScale = NULL;
+  ShiftScaleImageFilterType::Pointer scaleOnly = nullptr;
+  ShiftScaleInPlaceImageFilterType::Pointer shiftAndScale = nullptr;
   PhilipsRECImageIOType::ImageTypeRescaleValuesType rescaleValues = 
     rescaleValueVector->ElementAt(0); // Magnitude image is the first element.
   if( (rescaleValues[2] != 0) && // scale slope (SS)
@@ -331,7 +331,7 @@ int main(int argc, char **argv)
   extractionIndex[1] = 0;
   extractionIndex[2] = 0;
   extractionRegion.SetSize(extractionSize);
-  PhilipsRECImageIOType::EchoTimesContainerType::Pointer ptrToEchoes = NULL;
+  PhilipsRECImageIOType::EchoTimesContainerType::Pointer ptrToEchoes = nullptr;
   if(!itk::ExposeMetaData<PhilipsRECImageIOType::EchoTimesContainerType::Pointer>
     (imageIO->GetMetaDataDictionary(), itk::PAR_EchoTimes,ptrToEchoes) )
     {

--- a/itkBruker2DSEQImageIO.h
+++ b/itkBruker2DSEQImageIO.h
@@ -140,13 +140,13 @@ public:
        * \param FileNameToRead The name of the file to test for reading.
        * \return Returns true if this ImageIO can read the file specified.
        */
-  virtual bool CanReadFile(const char* FileNameToRead);
+  bool CanReadFile(const char* FileNameToRead) override;
 
   /** Set the spacing and dimension information for the set filename. */
-  virtual void ReadImageInformation();
+  void ReadImageInformation() override;
 
   /** Reads the data from disk into the memory buffer provided. */
-  virtual void Read(void* buffer);
+  void Read(void* buffer) override;
 
   /*-------- This part of the interfaces deals with writing data. ----- */
 
@@ -156,20 +156,20 @@ public:
        * \post This function will always return false (Not implemented).
        * \return Returns true if this ImageIO can write the file specified.
        */
-  virtual bool CanWriteFile( const char * itkNotUsed(FileNameToWrite) )
+  bool CanWriteFile( const char * itkNotUsed(FileNameToWrite) ) override
     {
     return false;
     }
 
   /** Set the spacing and dimension information for the set filename. */
-  virtual void WriteImageInformation() 
+  void WriteImageInformation() override
     { 
     return;
     }
 
   /** Writes the data to disk from the memory buffer provided. Make sure
        * that the IORegions has been set properly. */
-  virtual void Write( const void * itkNotUsed( buffer ) ) 
+  void Write( const void * itkNotUsed( buffer ) ) override
     { 
     return;
     }
@@ -177,8 +177,8 @@ public:
 
 protected:
   Bruker2DSEQImageIO();
-  ~Bruker2DSEQImageIO();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  ~Bruker2DSEQImageIO() override;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
 private:
 

--- a/itkBruker2DSEQImageIOFactory.h
+++ b/itkBruker2DSEQImageIOFactory.h
@@ -42,8 +42,8 @@ public:
   typedef SmartPointer<const Self>      ConstPointer;
   
   /** Class methods used to interface with the registered factories. */
-  virtual const char* GetITKSourceVersion(void) const;
-  virtual const char* GetDescription(void) const;
+  const char* GetITKSourceVersion(void) const override;
+  const char* GetDescription(void) const override;
     
   /** Method for class instantiation. */
   itkFactorylessNewMacro(Self);
@@ -61,7 +61,7 @@ public:
   
 protected:
   Bruker2DSEQImageIOFactory();
-  virtual ~Bruker2DSEQImageIOFactory();
+  ~Bruker2DSEQImageIOFactory() override;
 
 private:
   Bruker2DSEQImageIOFactory(const Self&); //purposely not implemented

--- a/itkFDFImageIO.h
+++ b/itkFDFImageIO.h
@@ -46,16 +46,16 @@ public:
 
   /** Determine the file type. Returns true if this ImageIO can read the
    * file specified. */
-  virtual bool CanReadFile(const char*);
+  bool CanReadFile(const char*) override;
 
   /** Set the spacing and diemention information for the set filename. */
-  virtual void ReadImageInformation();
+  void ReadImageInformation() override;
 
   /** Get the type of the pixel.  */
   //virtual const itk::ImageIOBase::IOPixelType GetPixelType() const;
 
   /** Reads the data from disk into the memory buffer provided. */
-  virtual void Read(void* buffer);
+  void Read(void* buffer) override;
 
   /** Reads 3D data from multiple files assuming one slice per file. */
   virtual void ReadVolume(void* buffer);
@@ -63,26 +63,26 @@ public:
   /** Compute the size (in bytes) of the components of a pixel. For
    * example, and RGB pixel of unsigned char would have a
    * component size of 1 byte. */
-  virtual unsigned int GetComponentSize() const;
+  unsigned int GetComponentSize() const override;
 
   /*-------- This part of the interfaces deals with writing data. ----- */
 
   /** Determine the file type. Returns true if this ImageIO can read the
    * file specified. */
-  virtual bool CanWriteFile(const char*);
+  bool CanWriteFile(const char*) override;
 
   /** Writes the spacing and dimentions of the image.
    * Assumes SetFileName has been called with a valid file name. */
-  virtual void WriteImageInformation();
+  void WriteImageInformation() override;
 
   /** Writes the data to disk from the memory buffer provided. Make sure
    * that the IORegion has been set properly. */
-  virtual void Write(const void* buffer);
+  void Write(const void* buffer) override;
 
 protected:
   FDFImageIO();
-  ~FDFImageIO();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  ~FDFImageIO() override;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   void WriteSlice(std::string& fileName, const void* buffer);
 

--- a/itkFDFImageIOFactory.h
+++ b/itkFDFImageIOFactory.h
@@ -35,8 +35,8 @@ public:
   typedef SmartPointer<const Self>  ConstPointer;
 
   /** Class methods used to interface with the registered factories. */
-  virtual const char* GetITKSourceVersion(void) const;
-  virtual const char* GetDescription(void) const;
+  const char* GetITKSourceVersion(void) const override;
+  const char* GetDescription(void) const override;
 
   /** Method for class instantiation. */
   itkFactorylessNewMacro(Self);
@@ -53,7 +53,7 @@ public:
 
 protected:
   FDFImageIOFactory();
-  ~FDFImageIOFactory();
+  ~FDFImageIOFactory() override;
 
 private:
   FDFImageIOFactory(const Self&); //purposely not implemented

--- a/itkMRT1ParameterMap3DImageFilter.h
+++ b/itkMRT1ParameterMap3DImageFilter.h
@@ -202,8 +202,8 @@ public:
 
 protected:
   MRT1ParameterMap3DImageFilter();
-  ~MRT1ParameterMap3DImageFilter() {};
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  ~MRT1ParameterMap3DImageFilter() override {};
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   void FitIdealSteadyState(ExponentialFitType X, ExponentialFitType Y,
       unsigned int num, MRParameterMapPixelType &output);
@@ -223,11 +223,11 @@ protected:
       unsigned int num, MRParameterMapPixelType &output);
 
   /** Setup vector image vector length. */
-  virtual void GenerateOutputInformation();
+  void GenerateOutputInformation() override;
 
-  void BeforeThreadedGenerateData();
+  void BeforeThreadedGenerateData() override;
   void ThreadedGenerateData( const
-      OutputImageRegionType &outputRegionForThread, ThreadIdType);
+      OutputImageRegionType &outputRegionForThread, ThreadIdType) override;
 
   /** enum to indicate if the MR echo image is specified as a single multi-
    * component image or as several separate images */

--- a/itkMRT1ParameterMap3DImageFilter.txx
+++ b/itkMRT1ParameterMap3DImageFilter.txx
@@ -49,13 +49,13 @@ public:
     return (t * a * exp( -t * b ));
     }
 
-  void f(vnl_vector<double> const& x, vnl_vector<double>& y) {
+  void f(vnl_vector<double> const& x, vnl_vector<double>& y) override {
     for (unsigned int i=0; i<this->m_NumSignals; ++i) {
       y[i] = compute(this->m_Time[i], x(0), x(1) ) - this->m_Signal[i];
       }
     }
 
-  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) {
+  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) override {
     for (unsigned int i=0; i<this->m_NumSignals; ++i) {
       J(i,0) = compute_a(this->m_Time[i], x(0), x(1) );
       }
@@ -91,13 +91,13 @@ public:
     return (t * a * exp( -t * c ));
     }
 
-  void f(vnl_vector<double> const& x, vnl_vector<double>& y) {
+  void f(vnl_vector<double> const& x, vnl_vector<double>& y) override {
     for (unsigned int i=0; i<this->m_NumSignals; ++i)       {
       y[i] = compute(this->m_Time[i], x(0), x(1), x(2) ) - this->m_Signal[i];
       }
     }
 
-  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) {
+  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) override {
     for (unsigned int i=0; i<this->m_NumSignals; ++i) {
       J(i,0) = compute_a(this->m_Time[i], x(0), x(1), x(2) );
       }
@@ -133,13 +133,13 @@ public:
     return (t * a * 2.0 * exp( -t * b ));
     }
 
-  void f(vnl_vector<double> const& x, vnl_vector<double>& y) {
+  void f(vnl_vector<double> const& x, vnl_vector<double>& y) override {
     for (unsigned int i=0; i<this->m_NumSignals; ++i) {
       y[i] = compute(this->m_Time[i], x(0), x(1) ) - this->m_Signal[i];
       }
     }
 
-  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) {
+  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) override {
     for (unsigned int i=0; i<this->m_NumSignals; ++i) {
       J(i,0) = compute_a(this->m_Time[i], x(0), x(1) );
       }
@@ -175,13 +175,13 @@ public:
     return (t * a * b * exp( -t * c ));
     }
 
-  void f(vnl_vector<double> const& x, vnl_vector<double>& y) {
+  void f(vnl_vector<double> const& x, vnl_vector<double>& y) override {
     for (unsigned int i=0; i<this->m_NumSignals; ++i)       {
       y[i] = compute(this->m_Time[i], x(0), x(1), x(2) ) - this->m_Signal[i];
       }
     }
 
-  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) {
+  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) override {
     for (unsigned int i=0; i<this->m_NumSignals; ++i) {
       J(i,0) = compute_a(this->m_Time[i], x(0), x(1), x(2) );
       }
@@ -210,7 +210,7 @@ MRT1ParameterMap3DImageFilter<TMRImagePixelType,TMRParameterMapImagePixelType>
   this->m_MaxT1Time = 10.0f;
   this->m_PerformR1Mapping = false;
   this->m_MRImageTypeEnumeration = Else;
-  this->m_TimeContainer = NULL;
+  this->m_TimeContainer = nullptr;
   this->m_Algorithm = IDEAL_STEADY_STATE;
 }
 
@@ -841,7 +841,7 @@ MRT1ParameterMap3DImageFilter<TMRImagePixelType,TMRParameterMapImagePixelType>
 
     for( unsigned int i = 0; i< this->m_NumberOfImages; i++ )
       {
-      typename MRImageType::Pointer mrImagePointer = NULL;
+      typename MRImageType::Pointer mrImagePointer = nullptr;
       
       mrImagePointer = static_cast< MRImageType * >( 
         this->ProcessObject::GetInput(i) );
@@ -965,7 +965,7 @@ MRT1ParameterMap3DImageFilter<TMRImagePixelType,TMRParameterMapImagePixelType>
     {
     typedef ImageRegionConstIterator< MRImagesType > MRImageIteratorType;
     typedef typename MRImagesType::PixelType         MREchoVectorType;
-    typename MRImagesType::Pointer mrImagePointer = NULL;
+    typename MRImagesType::Pointer mrImagePointer = nullptr;
     int nonzeroCount = 0;
 
     mrImagePointer = static_cast< MRImagesType * >(

--- a/itkMRT2ParameterMap3DImageFilter.h
+++ b/itkMRT2ParameterMap3DImageFilter.h
@@ -175,8 +175,8 @@ public:
   
 protected:
   MRT2ParameterMap3DImageFilter();
-  ~MRT2ParameterMap3DImageFilter() {};
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  ~MRT2ParameterMap3DImageFilter() override {};
+  void PrintSelf(std::ostream& os, Indent indent) const override;
   
   void FitLinearExponential(ExponentialFitType X, ExponentialFitType Y, 
     unsigned int num, MRParameterMapPixelType &output);
@@ -186,11 +186,11 @@ protected:
     ExponentialFitType Y, unsigned int num, MRParameterMapPixelType &output);
   
   /** Setup vector image vector length. */
-  virtual void GenerateOutputInformation();
+  void GenerateOutputInformation() override;
   
-  void BeforeThreadedGenerateData();
+  void BeforeThreadedGenerateData() override;
   void ThreadedGenerateData( const 
-      OutputImageRegionType &outputRegionForThread, ThreadIdType);
+      OutputImageRegionType &outputRegionForThread, ThreadIdType) override;
   
   /** enum to indicate if the MR echo image is specified as a single multi-
    * component image or as several separate images */

--- a/itkMRT2ParameterMap3DImageFilter.txx
+++ b/itkMRT2ParameterMap3DImageFilter.txx
@@ -49,13 +49,13 @@ public:
     return (- t * a * exp( -t * b ));
     }
 
-  void f(vnl_vector<double> const& x, vnl_vector<double>& y) {
+  void f(vnl_vector<double> const& x, vnl_vector<double>& y) override {
     for (unsigned int i=0; i<this->m_NSignals; ++i)       {
       y[i] = compute(this->m_Time[i], x(0), x(1) ) - this->m_Signal[i];
       }
     }
 
-  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) {
+  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) override {
     for (unsigned int i=0; i<this->m_NSignals; ++i) {
       J(i,0) = compute_a(this->m_Time[i], x(0), x(1) );
       }
@@ -91,13 +91,13 @@ public:
     return ( 1.0 );
     }
 
-  void f(vnl_vector<double> const& x, vnl_vector<double>& y) {
+  void f(vnl_vector<double> const& x, vnl_vector<double>& y) override {
     for (unsigned int i=0; i<this->m_NSignals; ++i)       {
       y[i] = compute(this->m_Time[i], x(0), x(1), x(2) ) - this->m_Signal[i];
       }
     }
 
-  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) {
+  void gradf(vnl_vector<double> const& x, vnl_matrix<double> &J) override {
     for (unsigned int i=0; i<this->m_NSignals; ++i) {
       J(i,0) = compute_a(this->m_Time[i], x(0), x(1), x(2) );
       }
@@ -126,7 +126,7 @@ MRT2ParameterMap3DImageFilter<TMREchoImagePixelType,
   this->m_MaxT2Time = 10.0f;
   this->m_PerformR2Mapping = false;
   this->m_MREchoImageTypeEnumeration = Else;
-  this->m_EchoTimeContainer = NULL;
+  this->m_EchoTimeContainer = nullptr;
   this->m_Algorithm = LINEAR;
 }
 
@@ -436,7 +436,7 @@ MRT2ParameterMap3DImageFilter<TMREchoImagePixelType,
 
     for( unsigned int i = 0; i< this->m_NumberOfEchoImages; i++ )
       {
-      typename MREchoImageType::Pointer echoImagePointer = NULL;
+      typename MREchoImageType::Pointer echoImagePointer = nullptr;
 
       echoImagePointer = static_cast< MREchoImageType * >(
         this->ProcessObject::GetInput(i) );
@@ -545,7 +545,7 @@ MRT2ParameterMap3DImageFilter<TMREchoImagePixelType,
     {
     typedef ImageRegionConstIterator< MREchoImagesType > MREchoIteratorType;
     typedef typename MREchoImagesType::PixelType         MREchoVectorType;
-    typename MREchoImagesType::Pointer echoImagePointer = NULL;
+    typename MREchoImagesType::Pointer echoImagePointer = nullptr;
     int nonzeroCount = 0;
 
     echoImagePointer = static_cast< MREchoImagesType * >(

--- a/itkPhilipsPAR.cxx
+++ b/itkPhilipsPAR.cxx
@@ -523,7 +523,7 @@ bool ReadPAR(std::string parFile, struct par_parameter* pPar)
   std::string::size_type index = 0;
   std::istringstream inString;
 
-  if( pPar == NULL )
+  if( pPar == nullptr )
     {
     std::cerr << "ReadPAR: pPar == NULL" << std::endl;
     return false;

--- a/itkPhilipsRECImageIO.cxx
+++ b/itkPhilipsRECImageIO.cxx
@@ -439,7 +439,7 @@ void PhilipsRECImageIO::Read(void* buffer)
   // In addition, it has the added benifit of reading gzip compressed image
   // files that do not have a .gz ending.
   gzFile file_p = ::gzopen( ImageFileName.c_str(), "rb" );
-  if( file_p == NULL )
+  if( file_p == nullptr )
     {
     ExceptionObject exception(__FILE__, __LINE__);
     std::string message="Philips REC Data File can not be read: "

--- a/itkPhilipsRECImageIO.h
+++ b/itkPhilipsRECImageIO.h
@@ -105,13 +105,13 @@ public:
        * \param FileNameToRead The name of the file to test for reading.
        * \return Returns true if this ImageIO can read the file specified.
        */
-  virtual bool CanReadFile(const char* FileNameToRead);
+  bool CanReadFile(const char* FileNameToRead) override;
 
   /** Set the spacing and dimension information for the set filename. */
-  virtual void ReadImageInformation();
+  void ReadImageInformation() override;
 
   /** Reads the data from disk into the memory buffer provided. */
-  virtual void Read(void* buffer);
+  void Read(void* buffer) override;
 
   /*-------- This part of the interfaces deals with writing data. ----- */
 
@@ -121,28 +121,28 @@ public:
        * \post This function will always return false (Not implemented).
        * \return Returns true if this ImageIO can write the file specified.
        */
-  virtual bool CanWriteFile( const char * itkNotUsed( FileNameToWrite ) )
+  bool CanWriteFile( const char * itkNotUsed( FileNameToWrite ) ) override
     {
     return false;
     }
 
   /** Set the spacing and dimension information for the set filename. */
-  virtual void WriteImageInformation()
+  void WriteImageInformation() override
     { 
     return;
     }
 
   /** Writes the data to disk from the memory buffer provided. Make sure
        * that the IORegions has been set properly. */
-  virtual void Write( const void * itkNotUsed(buffer) )
+  void Write( const void * itkNotUsed(buffer) ) override
     {
     return;
     }
 
 protected:
   PhilipsRECImageIO();
-  ~PhilipsRECImageIO();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  ~PhilipsRECImageIO() override;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
 private:
 

--- a/itkPhilipsRECImageIOFactory.h
+++ b/itkPhilipsRECImageIOFactory.h
@@ -42,8 +42,8 @@ public:
   typedef SmartPointer<const Self>      ConstPointer;
   
   /** Class methods used to interface with the registered factories. */
-  virtual const char* GetITKSourceVersion(void) const;
-  virtual const char* GetDescription(void) const;
+  const char* GetITKSourceVersion(void) const override;
+  const char* GetDescription(void) const override;
     
   /** Method for class instantiation. */
   itkFactorylessNewMacro(Self);
@@ -65,7 +65,7 @@ public:
   
 protected:
   PhilipsRECImageIOFactory();
-  ~PhilipsRECImageIOFactory();
+  ~PhilipsRECImageIOFactory() override;
 
 private:
   PhilipsRECImageIOFactory(const Self&); //purposely not implemented


### PR DESCRIPTION
The check converts the usage of null pointer constants (eg. NULL, 0) to
use the new C++11 nullptr keyword.

SRCDIR=/Users/johnsonhj/src/NEP-11/MRParameterMaps #My local SRC
BLDDIR=/Users/johnsonhj/src/NEP-11/MRParameterMaps-build/ #My local BLD

cd /Users/johnsonhj/src/NEP-11/MRParameterMaps-build/
run-clang-tidy.py -checks=-*,modernize-use-nullptr  -header-filter=.* -fix

STYLE: Use override statements for C++11

Describe function overrides using the override
keyword from C++11.

SRCDIR=/Users/johnsonhj/src/NEP-11/MRParameterMaps #My local SRC
BLDDIR=/Users/johnsonhj/src/NEP-11/MRParameterMaps-build/ #My local BLD

cd /Users/johnsonhj/src/NEP-11/MRParameterMaps-build/
run-clang-tidy.py -checks=-*,modernize-use-override  -header-filter=.* -fix